### PR TITLE
feat(atp): build directly from atp source (1/2)

### DIFF
--- a/.github/workflows/build-atp.yml
+++ b/.github/workflows/build-atp.yml
@@ -1,0 +1,76 @@
+name: Build ATP image
+permissions:
+  contents: write
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - atp-common/Containerfile
+      - .github/workflows/build-atp.yml
+    pull_request:
+      paths:
+        - atp-common/Containerfile
+        - .github/workflows/build-atp.yml
+  workflow_dispatch:
+
+env:
+  IMAGE_DESC: "OCI image for ATP"
+  IMAGE_KEYWORDS: "ATP"
+  IMAGE_NAME: "atp-common"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+  DEFAULT_TAG: "latest"
+
+jobs:
+  build-push:
+    name: Build ATP
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Build ATP image
+        run: podman build -t "${IMAGE_NAME}:${DEFAULT_TAG}" -f ./atp-common/Containerfile .
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push To GHCR
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        id: push
+        env:
+          REGISTRY_USER: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ github.token }}
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          image: ${{ env.IMAGE_NAME }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        with:
+          cosign-release: "v2.6.1"
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:${{ env.DEFAULT_TAG }}
+
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/build-atp.yml
+++ b/.github/workflows/build-atp.yml
@@ -66,9 +66,9 @@ jobs:
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         run: |
           IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY $IMAGE_FULL:${{ env.DEFAULT_TAG }}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE_FULL}@${DIGEST}"
 
         env:
-          TAGS: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/.github/workflows/build-atp.yml
+++ b/.github/workflows/build-atp.yml
@@ -3,8 +3,6 @@ permissions:
   contents: write
 on:
   push:
-    branches:
-      - main
     paths:
       - atp-common/Containerfile
       - .github/workflows/build-atp.yml

--- a/.github/workflows/build-atp.yml
+++ b/.github/workflows/build-atp.yml
@@ -8,10 +8,10 @@ on:
     paths:
       - atp-common/Containerfile
       - .github/workflows/build-atp.yml
-    pull_request:
-      paths:
-        - atp-common/Containerfile
-        - .github/workflows/build-atp.yml
+  pull_request:
+    paths:
+      - atp-common/Containerfile
+      - .github/workflows/build-atp.yml
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: bluebuild
 on:
   schedule:
-    - cron:
-        "00 06 * * 3" # build at 06:00 UTC every Wednesday
+    - cron: "00 06 * * 3" # build at 06:00 UTC every Wednesday
   push:
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
@@ -29,11 +28,12 @@ jobs:
           - recipe-nvidia.yml
     steps:
       - name: Build Custom Image
-        uses: blue-build/github-action@v1.8
+        uses: blue-build/github-action@v1.11
         with:
           recipe: ${{ matrix.recipe }}
           cosign_private_key: ${{ secrets.SIGNING_SECRET }}
           registry_token: ${{ github.token }}
           pr_event_number: ${{ github.event.number }}
           maximize_build_space: true
+          push: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'false' || 'true' }}
           build_opts: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '--no-sign' || '' }}

--- a/atp-common/Containerfile
+++ b/atp-common/Containerfile
@@ -1,0 +1,77 @@
+FROM ghcr.io/ublue-os/kinoite-main AS builder
+
+# Install build dependencies
+RUN dnf5 install -y gcc \
+                    gcc-c++ \
+                    cmake \
+                    make \
+                    extra-cmake-modules \
+                    ninja-build \
+                    plasma-workspace-devel \
+                    libksysguard-devel \
+                    unzip \
+                    kvantum \
+                    qt6-qtmultimedia-devel \
+                    qt6-qt5compat-devel \
+                    libplasma-devel \
+                    qt6-qtbase-devel \
+                    qt6-qtwayland-devel \
+                    plasma-activities-devel \
+                    kf6-kpackage-devel \
+                    kf6-kglobalaccel-devel \
+                    qt6-qtsvg-devel \
+                    wayland-devel \
+                    plasma-wayland-protocols \
+                    kf6-ksvg-devel \
+                    kf6-kcrash-devel \
+                    kf6-kguiaddons-devel \
+                    kf6-kcmutils-devel \
+                    kf6-kio-devel \
+                    kdecoration-devel \
+                    kf6-ki18n-devel \
+                    kf6-knotifications-devel \
+                    kf6-kirigami-devel \
+                    kf6-kiconthemes-devel \
+                    gmp-ecm-devel \
+                    kf5-plasma-devel \
+                    libepoxy-devel \
+                    kwin-devel \
+                    kf6-karchive \
+                    kf6-karchive-devel \
+                    plasma-wayland-protocols-devel \
+                    qt6-qtbase-private-devel \
+                    qt6-qtbase-devel \
+                    kf6-knewstuff-devel \
+                    kf6-knotifyconfig-devel \
+                    kf6-attica-devel \
+                    kf6-krunner-devel \
+                    kf6-kdbusaddons-devel \
+                    kf6-sonnet-devel \
+                    plasma5support-devel \
+                    plasma-activities-stats-devel \
+                    polkit-qt6-1-devel \
+                    qt-devel \
+                    libdrm-devel \
+                    kf6-kitemmodels-devel \
+                    kf6-kstatusnotifieritem-devel \
+                    kf6-frameworkintegration-devel
+
+# Build ATP
+WORKDIR /build
+RUN git clone https://gitgud.io/wackyideas/aerothemeplasma.git --depth 1
+WORKDIR /build/aerothemeplasma
+
+RUN mkdir -p /usr/local/share/mime/packages
+RUN CMAKE_GENERATOR=Ninja bash install.sh --skip-x11
+
+# Prepare required files
+RUN mkdir -p /build/aerothemeplasma/system_files && \
+    for manifest in /build/aerothemeplasma/manifest/*manifest.txt; do \
+        while read -r file; do \
+            mkdir -p "/build/aerothemeplasma/system_files/$(dirname "$file")" && \
+            cp -r "$file" "/build/aerothemeplasma/system_files/$file"; \
+        done < "$manifest"; \
+    done
+
+FROM scratch AS ctx
+COPY --from=builder /build/aerothemeplasma/system_files /system_files

--- a/atp-common/Containerfile
+++ b/atp-common/Containerfile
@@ -60,7 +60,7 @@ WORKDIR /build
 RUN git clone https://gitgud.io/wackyideas/aerothemeplasma.git --depth 1
 WORKDIR /build/aerothemeplasma
 
-RUN mkdir -p /usr/local/share/mime/packages
+RUN mkdir -p /usr/local/share/mime/packages || true
 RUN CMAKE_GENERATOR=Ninja bash install.sh --skip-x11
 
 # Prepare required files

--- a/atp-common/Containerfile
+++ b/atp-common/Containerfile
@@ -61,7 +61,7 @@ WORKDIR /build
 RUN git clone https://gitgud.io/wackyideas/aerothemeplasma.git --depth 1
 WORKDIR /build/aerothemeplasma
 
-RUN mkdir -p /usr/local/share/mime/packages
+RUN mkdir -p /usr/local/share/mime/packages || true
 RUN CMAKE_GENERATOR=Ninja bash install.sh --skip-x11
 
 # Prepare required files

--- a/atp-common/Containerfile
+++ b/atp-common/Containerfile
@@ -40,7 +40,6 @@ RUN dnf5 install -y gcc \
                     kf6-karchive-devel \
                     plasma-wayland-protocols-devel \
                     qt6-qtbase-private-devel \
-                    qt6-qtbase-devel \
                     kf6-knewstuff-devel \
                     kf6-knotifyconfig-devel \
                     kf6-attica-devel \
@@ -61,7 +60,7 @@ WORKDIR /build
 RUN git clone https://gitgud.io/wackyideas/aerothemeplasma.git --depth 1
 WORKDIR /build/aerothemeplasma
 
-RUN mkdir -p /usr/local/share/mime/packages || true
+RUN mkdir -p /usr/local/share/mime/packages
 RUN CMAKE_GENERATOR=Ninja bash install.sh --skip-x11
 
 # Prepare required files


### PR DESCRIPTION
Related to #44 
This PR adds a Dockerfile and github action config file in order to build ATP from a kinoite ublue image (closest to bazzite).
Then it copies all files to the correct file structure and publish an atp-common image that can be imported (simply by copying the file to the image) in future builds of winblues7.