### PR TITLE
Fix missing AeroThemePlasma files

### DIFF
--- a/atp-common/Containerfile
+++ b/atp-common/Containerfile
@@ -66,7 +66,7 @@ RUN CMAKE_GENERATOR=Ninja bash install.sh --skip-x11
 # Prepare required files
 RUN mkdir -p /build/aerothemeplasma/system_files && \
     for manifest in /build/aerothemeplasma/manifest/*manifest.txt; do \
-        while read -r file; do \
+        while read -r file || [[ -n "$file" ]]; do \
             mkdir -p "/build/aerothemeplasma/system_files/$(dirname "$file")" && \
             cp -r "$file" "/build/aerothemeplasma/system_files/$file"; \
         done < "$manifest"; \


### PR DESCRIPTION
The containerfile that builds the theme uses the manifest files to determine what to copy into the final Docker image. Since they do not have newlines at the end of them, read ignores the last line of the file and ends the loop. This fixes that.